### PR TITLE
BUGFIX: Blocks were being read as likes received. They are now exclud…

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@ function makeStats(matchData) {
 	window.matchData = matchData;
 
 	const likes_sent = matchData.filter(m => m.like).length;
-	const likes_received = matchData.length - likes_sent;
+	const blocks = matchData.filter(m => !m.like && m.block && !m.match).length
+	//blocks and likes sent must be subtracted from matchdata.length to get accurate likes received data.
+	const likes_received = matchData.length - blocks - likes_sent;
 	const total_likes = likes_sent + likes_received;
 
 	const matches_from_likes_sent = matchData.filter(m => m.like && m.match).length;


### PR DESCRIPTION
When you block a user without sending/receiving a like, it appears in matches.json as a block type entry in the following format:
	
    {
        "block": [
            {
                "block_type": "remove",
                "timestamp": "[Timestamp]",
                "type": "block"
            }
        ]
    },
    
    
Previously this was appearing as a like received.